### PR TITLE
[HEAP-27666] Implement track call

### DIFF
--- a/action-destinations.iml
+++ b/action-destinations.iml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="WEB_MODULE" version="4">
+  <component name="NewModuleRootManager" inherit-compiler-output="true">
+    <exclude-output />
+    <content url="file://$MODULE_DIR$" />
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/packages/browser-destinations/src/destinations/heap/constants.ts
+++ b/packages/browser-destinations/src/destinations/heap/constants.ts
@@ -1,0 +1,1 @@
+export const HEAP_LIBRARY_NAME = 'segment'

--- a/packages/browser-destinations/src/destinations/heap/trackEvent/generated-types.ts
+++ b/packages/browser-destinations/src/destinations/heap/trackEvent/generated-types.ts
@@ -1,0 +1,14 @@
+// Generated file. DO NOT MODIFY IT BY HAND.
+
+export interface Payload {
+  /**
+   * The name of the event.
+   */
+  name: string
+  /**
+   * A JSON object containing additional information about the event that will be indexed by Heap.
+   */
+  properties?: {
+    [k: string]: unknown
+  }
+}

--- a/packages/browser-destinations/src/destinations/heap/trackEvent/index.ts
+++ b/packages/browser-destinations/src/destinations/heap/trackEvent/index.ts
@@ -2,6 +2,7 @@ import type { BrowserActionDefinition } from '../../../lib/browser-destinations'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
 import { HeapApi } from '../types'
+import { HEAP_LIBRARY_NAME } from '../constants'
 
 const action: BrowserActionDefinition<Settings, HeapApi, Payload> = {
   title: 'Track Event',
@@ -29,7 +30,7 @@ const action: BrowserActionDefinition<Settings, HeapApi, Payload> = {
     }
   },
   perform: (heap, event) => {
-    heap.track(event.payload.name, event.payload.properties ?? {})
+    heap.track(event.payload.name, event.payload.properties ?? {}, HEAP_LIBRARY_NAME)
   }
 }
 

--- a/packages/browser-destinations/src/destinations/heap/trackEvent/index.ts
+++ b/packages/browser-destinations/src/destinations/heap/trackEvent/index.ts
@@ -1,0 +1,36 @@
+import type { BrowserActionDefinition } from '../../../lib/browser-destinations'
+import type { Settings } from '../generated-types'
+import type { Payload } from './generated-types'
+import { HeapApi } from '../types'
+
+const action: BrowserActionDefinition<Settings, HeapApi, Payload> = {
+  title: 'Track Event',
+  description: 'Track events',
+  platform: 'web',
+  defaultSubscription: 'type = "track"',
+  fields: {
+    name: {
+      description: 'The name of the event.',
+      label: 'Name',
+      required: true,
+      type: 'string',
+      default: {
+        '@path': '$.event'
+      }
+    },
+    properties: {
+      description: 'A JSON object containing additional information about the event that will be indexed by Heap.',
+      label: 'Properties',
+      required: false,
+      type: 'object',
+      default: {
+        '@path': '$.properties'
+      }
+    }
+  },
+  perform: (heap, event) => {
+    heap.track(event.payload.name, event.payload.properties ?? {})
+  }
+}
+
+export default action


### PR DESCRIPTION
I'm going to add unit tests later, once running them locally works.

----

Paste this in the settings box on `localhost:9000`

```
{
 "subscriptions": [
  {
   "partnerAction": "trackEvent",
   "name": "Track Event",
   "enabled": true,
   "subscribe": "type = \"track\"",
   "mapping": {
    "name": {
     "@path": "$.event"
    },
    "properties": {
     "@path": "$.properties"
    }
   }
  }
 ],
 "appId": "3632889160"
}
```

Then click `Track` down below. Event should appear in Heap live view.

![image](https://user-images.githubusercontent.com/1471473/158155447-94b4b9b5-8e80-42bf-a3da-21c497a085f8.png)

