### PR TITLE
[HEAP-27667] Implement identify call

### DIFF
--- a/packages/browser-destinations/src/destinations/heap/identifyUser/generated-types.ts
+++ b/packages/browser-destinations/src/destinations/heap/identifyUser/generated-types.ts
@@ -1,0 +1,8 @@
+// Generated file. DO NOT MODIFY IT BY HAND.
+
+export interface Payload {
+  /**
+   * The user's identity
+   */
+  userId?: string
+}

--- a/packages/browser-destinations/src/destinations/heap/identifyUser/index.ts
+++ b/packages/browser-destinations/src/destinations/heap/identifyUser/index.ts
@@ -1,0 +1,29 @@
+import type { BrowserActionDefinition } from '../../../lib/browser-destinations'
+import type { Settings } from '../generated-types'
+import type { Payload } from './generated-types'
+import { HeapApi } from '../types'
+
+const action: BrowserActionDefinition<Settings, HeapApi, Payload> = {
+  title: 'Identify User',
+  description: 'Sets user identity',
+  platform: 'web',
+  defaultSubscription: 'type = "identify"',
+  fields: {
+    userId: {
+      type: 'string',
+      required: false,
+      description: "The user's identity",
+      label: 'Identity',
+      default: {
+        '@path': '$.userId'
+      }
+    }
+  },
+  perform: (heap, event) => {
+    if (event.payload.userId) {
+      heap.identify(event.payload.userId)
+    }
+  }
+}
+
+export default action

--- a/packages/browser-destinations/src/destinations/heap/index.ts
+++ b/packages/browser-destinations/src/destinations/heap/index.ts
@@ -4,6 +4,7 @@ import { browserDestination } from '../../runtime/shim'
 import { HeapApi } from './types'
 import { defaultValues } from '@segment/actions-core'
 import trackEvent from './trackEvent'
+import identifyUser from './identifyUser'
 
 declare global {
   interface Window {
@@ -22,6 +23,12 @@ export const destination: BrowserDestinationDefinition<Settings, HeapApi> = {
       subscribe: 'type = "track"',
       partnerAction: 'trackEvent',
       mapping: defaultValues(trackEvent.fields)
+    },
+    {
+      name: 'Identify User',
+      subscribe: 'type = "identify"',
+      partnerAction: 'identifyUser',
+      mapping: defaultValues(identifyUser.fields)
     }
   ],
   settings: {
@@ -67,7 +74,8 @@ export const destination: BrowserDestinationDefinition<Settings, HeapApi> = {
   },
 
   actions: {
-    trackEvent
+    trackEvent,
+    identifyUser
   }
 }
 

--- a/packages/browser-destinations/src/destinations/heap/types.ts
+++ b/packages/browser-destinations/src/destinations/heap/types.ts
@@ -8,4 +8,5 @@ export interface HeapApi {
   track: Function
   load: Function
   config: UserConfig
+  identify: Function
 }


### PR DESCRIPTION
Testing:

Paste this in the settings box:

```
{
 "subscriptions": [
  {
   "partnerAction": "trackEvent",
   "name": "Track Event",
   "enabled": true,
   "subscribe": "type = \"track\"",
   "mapping": {
    "name": {
     "@path": "$.event"
    },
    "properties": {
     "@path": "$.properties"
    }
   }
  },
  {
   "partnerAction": "identifyUser",
   "name": "Identify User",
   "enabled": true,
   "subscribe": "type = \"identify\"",
   "mapping": {
    "userId": {
     "@path": "$.userId"
    }
   }
  }
 ],
 "appId": "3632889160"
}
```

Paste this in the event box:

```
{
 "name": "Segment Browser Action - Track",
 "event": "E NAME",
 "userId": "42",
 "properties": {"testProperty": "testPropertyValue"},
 "traits": {},
 "options": {}
}
```

Click Identify button.

User with identity 42 will appear in Heap.

![image](https://user-images.githubusercontent.com/1471473/158369366-427de91e-9297-4812-b67f-1836ea84e1f2.png)
