### PR TITLE
[HEAP-29359] Track user properties

### DIFF
--- a/packages/browser-destinations/src/destinations/heap/identifyUser/__tests__/index.test.ts
+++ b/packages/browser-destinations/src/destinations/heap/identifyUser/__tests__/index.test.ts
@@ -38,18 +38,41 @@ describe('#identify', () => {
 
     await identifyUser.load(Context.system(), {} as Analytics)
     const heapIdentifySpy = jest.spyOn(window.heap, 'identify')
+    const heapAddUserPropertiesSpy = jest.spyOn(window.heap, 'addUserProperties')
 
     await identifyUser.identify?.(
       new Context({
         type: 'identify',
         anonymousId: 'anon',
-        userId: 'user@example.com',
+        userId: 'user@example.com'
+      })
+    )
+
+    expect(heapIdentifySpy).toHaveBeenCalledWith('user@example.com')
+    expect(heapAddUserPropertiesSpy).not.toHaveBeenCalled()
+  })
+
+  it('should call addUserProprties if traits are provided', async () => {
+    mockHeapJsHttpRequest()
+    window.heap = createMocekdHeapJsSdk()
+
+    const [identifyUser] = await heapDestination({ appId: HEAP_TEST_ENV_ID, subscriptions: [identifyUserSubscription] })
+
+    await identifyUser.load(Context.system(), {} as Analytics)
+    const heapIdentifySpy = jest.spyOn(window.heap, 'identify')
+    const heapAddUserPropertiesSpy = jest.spyOn(window.heap, 'addUserProperties')
+
+    await identifyUser.identify?.(
+      new Context({
+        type: 'identify',
+        anonymousId: 'anon',
         traits: {
           testProp: false
         }
       })
     )
 
-    expect(heapIdentifySpy).toHaveBeenCalledWith('user@example.com')
+    expect(heapIdentifySpy).not.toHaveBeenCalled()
+    expect(heapAddUserPropertiesSpy).toHaveBeenCalledWith({ testProp: false })
   })
 })

--- a/packages/browser-destinations/src/destinations/heap/identifyUser/generated-types.ts
+++ b/packages/browser-destinations/src/destinations/heap/identifyUser/generated-types.ts
@@ -5,4 +5,10 @@ export interface Payload {
    * The user's identity
    */
   userId?: string
+  /**
+   * The Segment traits to be forwarded to Heap
+   */
+  traits?: {
+    [k: string]: unknown
+  }
 }

--- a/packages/browser-destinations/src/destinations/heap/identifyUser/index.ts
+++ b/packages/browser-destinations/src/destinations/heap/identifyUser/index.ts
@@ -17,9 +17,21 @@ const action: BrowserActionDefinition<Settings, HeapApi, Payload> = {
       default: {
         '@path': '$.userId'
       }
+    },
+    traits: {
+      type: 'object',
+      required: false,
+      description: 'The Segment traits to be forwarded to Heap',
+      label: 'Traits',
+      default: {
+        '@path': '$.traits'
+      }
     }
   },
   perform: (heap, event) => {
+    if (event.payload.traits) {
+      heap.addUserProperties(event.payload.traits)
+    }
     if (event.payload.userId) {
       heap.identify(event.payload.userId)
     }

--- a/packages/browser-destinations/src/destinations/heap/test-utilities.ts
+++ b/packages/browser-destinations/src/destinations/heap/test-utilities.ts
@@ -13,7 +13,8 @@ export const createMocekdHeapJsSdk = (): HeapApi => {
     },
     load: jest.fn(),
     track: jest.fn(),
-    identify: jest.fn()
+    identify: jest.fn(),
+    addUserProperties: jest.fn()
   }
 }
 export const trackEventSubscription: Subscription = {
@@ -43,14 +44,8 @@ export const identifyUserSubscription: Subscription = {
     userId: {
       '@path': '$.userId'
     },
-    email: {
-      '@path': '$.traits.email'
-    },
     traits: {
       '@path': '$.traits'
-    },
-    displayName: {
-      '@path': '$.traits.name'
     }
   }
 }

--- a/packages/browser-destinations/src/destinations/heap/types.ts
+++ b/packages/browser-destinations/src/destinations/heap/types.ts
@@ -3,10 +3,15 @@ export type UserConfig = {
   secureCookie: boolean
 }
 
+interface UserProperties {
+  [k: string]: unknown
+}
+
 export interface HeapApi {
   appid: string
   track: (eventName: string, eventProperties: { [key: string]: unknown }, library: string) => void
-  load: Function
+  load: () => void
   config: UserConfig
   identify: (identity: string) => void
+  addUserProperties: (properties: UserProperties) => void
 }


### PR DESCRIPTION
User properties are passed as `traits` during the identify call. Verified that calling `addUserProperties` works in the browser in the dev environment.