### PR TITLE
[HEAP-31206] Send segment_library property

### DIFF
--- a/packages/browser-destinations/src/destinations/heap/trackEvent/__tests__/index.test.ts
+++ b/packages/browser-destinations/src/destinations/heap/trackEvent/__tests__/index.test.ts
@@ -27,12 +27,8 @@ describe('#trackEvent', () => {
       })
     )
 
-    expect(heapTrackSpy).toHaveBeenCalledWith(
-      'hello!',
-      {
-        banana: '📞'
-      },
-      'segment'
-    )
+    expect(heapTrackSpy).toHaveBeenCalledWith('hello!', {
+      banana: '📞'
+    })
   })
 })

--- a/packages/browser-destinations/src/destinations/heap/trackEvent/index.ts
+++ b/packages/browser-destinations/src/destinations/heap/trackEvent/index.ts
@@ -3,6 +3,8 @@ import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
 import { HeapApi } from '../types'
 
+export const HEAP_SEGMENT_LIBRARY_NAME = 'destinations-actions'
+
 const action: BrowserActionDefinition<Settings, HeapApi, Payload> = {
   title: 'Track Event',
   description: 'Track events',
@@ -29,7 +31,9 @@ const action: BrowserActionDefinition<Settings, HeapApi, Payload> = {
     }
   },
   perform: (heap, event) => {
-    heap.track(event.payload.name, event.payload.properties ?? {})
+    const defaultEventProperties = { segment_library: HEAP_SEGMENT_LIBRARY_NAME }
+    const eventProperties = Object.assign(defaultEventProperties, event.payload.properties ?? {})
+    heap.track(event.payload.name, eventProperties)
   }
 }
 

--- a/packages/browser-destinations/src/destinations/heap/trackEvent/index.ts
+++ b/packages/browser-destinations/src/destinations/heap/trackEvent/index.ts
@@ -2,7 +2,6 @@ import type { BrowserActionDefinition } from '../../../lib/browser-destinations'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
 import { HeapApi } from '../types'
-import { HEAP_LIBRARY_NAME } from '../constants'
 
 const action: BrowserActionDefinition<Settings, HeapApi, Payload> = {
   title: 'Track Event',
@@ -30,7 +29,7 @@ const action: BrowserActionDefinition<Settings, HeapApi, Payload> = {
     }
   },
   perform: (heap, event) => {
-    heap.track(event.payload.name, event.payload.properties ?? {}, HEAP_LIBRARY_NAME)
+    heap.track(event.payload.name, event.payload.properties ?? {})
   }
 }
 

--- a/packages/browser-destinations/src/destinations/heap/types.ts
+++ b/packages/browser-destinations/src/destinations/heap/types.ts
@@ -13,7 +13,7 @@ type EventProperties = {
 
 export type HeapApi = {
   appid: string
-  track: (eventName: string, eventProperties: EventProperties, library: string) => void
+  track: (eventName: string, eventProperties: EventProperties, library?: string) => void
   load: () => void
   config: UserConfig
   identify: (identity: string) => void


### PR DESCRIPTION
I know that we haven't decided on the value of `segment_library` yet but it's easy to update.

This change adds `segment_library` property to all `heap.track` calls. However, if there's a user-provided value, we don't override it and send the original.