### PR TITLE
[PA-4600] feat(heap): update browser destination code to load heap js v5 script

### DIFF
--- a/packages/browser-destinations/destinations/heap/src/generated-types.ts
+++ b/packages/browser-destinations/destinations/heap/src/generated-types.ts
@@ -14,9 +14,13 @@ export interface Settings {
    */
   secureCookie?: boolean
   /**
-   * This is an optional setting. This is used to set up first-party data collection. For most cased this should not be set. For more information visit the heap [docs page](https://developers.heap.io/docs/set-up-first-party-data-collection-in-heap).
+   * This is an optional setting. This is used to set up first-party data collection. For most cased this should not be set. For more information visit the heap [docs page](https://developers.heap.io/docs/set-up-first-party-data-collection-in-heap). This field is deprecated in favor of "ingestServer".
    */
   trackingServer?: string
+  /**
+   * This is an optional setting. This is used to set up first-party data collection. For most cased this should not be set. For more information visit the heap [docs page](https://developers.heap.io/docs/web#ingestserver).
+   */
+  ingestServer?: string
   /**
    * This is an optional setting used to set the host that loads heap-js. This setting is used when heapJS is self-hosted. In most cased this should be left unset. The hostname should not contain https or app id it will be populated like so: https://${hostname}/js/heap-${appId}.js. For more information visit the heap [docs page](https://developers.heap.io/docs/self-hosting-heapjs).
    */

--- a/packages/browser-destinations/destinations/heap/src/init-script.ts
+++ b/packages/browser-destinations/destinations/heap/src/init-script.ts
@@ -1,0 +1,69 @@
+import type { HeapMethods, UserConfig } from './types'
+
+/**
+ * Initialize the Heap script with the provided environment ID and configuration.
+ */
+export const initScript = (envId: string, config: UserConfig) => {
+  // Ensure heapReadyCb exists on the window object
+  window.heapReadyCb = window.heapReadyCb || []
+
+  // Ensure heap exists on the window object
+  window.heap = window.heap || ({} as any)
+
+  window.heap.load = function (
+    envId: string,
+    clientConfig: UserConfig = { disableTextCapture: false, secureCookie: false }
+  ): void {
+    window.heap.envId = envId
+    window.heap.clientConfig = clientConfig
+    window.heap.clientConfig.shouldFetchServerConfig = false
+
+    // Define all Heap API methods and add them to the heap object
+    const methods: HeapMethods[] = [
+      'init',
+      'startTracking',
+      'stopTracking',
+      'track',
+      'resetIdentity',
+      'identify',
+      'identifyHashed',
+      'getSessionId',
+      'getUserId',
+      'getIdentity',
+      'addUserProperties',
+      'addEventProperties',
+      'removeEventProperty',
+      'clearEventProperties',
+      'addAccountProperties',
+      'addAdapter',
+      'addTransformer',
+      'addTransformerFn',
+      'onReady',
+      'addPageviewProperties',
+      'removePageviewProperty',
+      'clearPageviewProperties',
+      'trackPageview'
+    ]
+
+    const createMethodProxy = (methodName: HeapMethods) => {
+      return function (...args: any[]) {
+        // Push method calls to heapReadyCb until the script is fully loaded
+        window.heapReadyCb.push({
+          name: methodName,
+          fn: () => {
+            if (window.heap[methodName]) {
+              window.heap[methodName](...args)
+            }
+          }
+        })
+      }
+    }
+
+    // Proxy all methods to heap
+    for (const method of methods) {
+      window.heap[method] = createMethodProxy(method)
+    }
+  }
+
+  window.heap.load(envId, config)
+}

--- a/packages/browser-destinations/destinations/heap/src/test-utilities.ts
+++ b/packages/browser-destinations/destinations/heap/src/test-utilities.ts
@@ -7,6 +7,7 @@ export const HEAP_TEST_ENV_ID = '1'
 export const createMockedHeapJsSdk = (): HeapApi => {
   return {
     appid: HEAP_TEST_ENV_ID,
+    envId: HEAP_TEST_ENV_ID,
     config: {
       disableTextCapture: true,
       secureCookie: true

--- a/packages/browser-destinations/destinations/heap/src/types.ts
+++ b/packages/browser-destinations/destinations/heap/src/types.ts
@@ -1,5 +1,6 @@
 export type UserConfig = {
   trackingServer?: string
+  ingestServer?: string
   disableTextCapture: boolean
   secureCookie: boolean
 }
@@ -14,9 +15,38 @@ type EventProperties = {
 
 export type HeapApi = {
   appid: string
+  envId: string
   track: (eventName: string, eventProperties: EventProperties, library?: string) => void
-  load: () => void
+  load: (envId: string, clientConfig?: UserConfig) => void
+  loaded?: boolean
   config: UserConfig
+  clientConfig?: Partial<UserConfig> & { shouldFetchServerConfig?: boolean }
   identify: (identity: string) => void
   addUserProperties: (properties: UserProperties) => void
 }
+
+// Define types for Heap methods
+export type HeapMethods =
+  | 'init'
+  | 'startTracking'
+  | 'stopTracking'
+  | 'track'
+  | 'resetIdentity'
+  | 'identify'
+  | 'identifyHashed'
+  | 'getSessionId'
+  | 'getUserId'
+  | 'getIdentity'
+  | 'addUserProperties'
+  | 'addEventProperties'
+  | 'removeEventProperty'
+  | 'clearEventProperties'
+  | 'addAccountProperties'
+  | 'addAdapter'
+  | 'addTransformer'
+  | 'addTransformerFn'
+  | 'onReady'
+  | 'addPageviewProperties'
+  | 'removePageviewProperty'
+  | 'clearPageviewProperties'
+  | 'trackPageview'


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

## Summary
Update the Heap browser destination to use v5 of Heap's javascript snippet.

### The Problem

Customers are running into issues with TikTok. We've seen that TT browser web views will strip duplicate key/value pairs on `GET` requests as an "optimization". Our request schema uses an arbitrary key for custom properties. For example, we'll have the query params: `k=name1&k=false&k=name2&k=false&k=name3&k=true`, but because of the way TT "optimizes", it will intercept the request before firing off and remove any duplicate query param values, leading to the request being fired having: `k=name1&k=false&k=name2&k=name3&k=true`, which ends up causing mismatched k/v pairing on the custom properties when we parse the request on the server-side.

### The Solution
By upgrading to v5, we replace GET requests with POST so this fixes the issue.

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [If destination is already live] Tested for backward compatibility of destination. **Note:** New required fields are a breaking change.
- [ ] [Segmenters] Tested in the staging environment
- [ ] [Segmenters] [If applicable for this change] Tested for regression with Hadron. 
